### PR TITLE
Enable multiple ldap trees and servers for authentication

### DIFF
--- a/attributes/ldap_config.rb
+++ b/attributes/ldap_config.rb
@@ -1,4 +1,9 @@
 default['grafana']['ldap_verbose_logging'] = false
+default['grafana']['ldap_multi_tree_auth'] = false
+# When the ldap_multi_tree_auth attribute is set to true, it is possible to configure
+# several ldap servers by using default['grafana']['ldap'][0],
+# default['grafana']['ldap'][1]['[servers]']['host'], etc. instead of
+# default['grafana']['ldap']['[servers]'] with the same syntax.
 
 default['grafana']['ldap']['[servers]']['host'] = {
   comment: 'Ldap server host',

--- a/attributes/ldap_config.rb
+++ b/attributes/ldap_config.rb
@@ -1,8 +1,8 @@
 default['grafana']['ldap_verbose_logging'] = false
 default['grafana']['ldap_multi_tree_auth'] = false
 # When the ldap_multi_tree_auth attribute is set to true, it is possible to configure
-# several ldap servers by using default['grafana']['ldap'][0],
-# default['grafana']['ldap'][1]['[servers]']['host'], etc. instead of
+# several ldap servers by using default['grafana']['ldap']['multiconfig']['first_server'],
+# default['grafana']['ldap']['multiconfig']['first_server']['[servers]']['host'], etc. instead of
 # default['grafana']['ldap']['[servers]'] with the same syntax.
 
 default['grafana']['ldap']['[servers]']['host'] = {

--- a/libraries/ini_helper.rb
+++ b/libraries/ini_helper.rb
@@ -2,10 +2,8 @@ module GrafanaCookbook
   module IniHelper
     def self.format_multi_config(multi_config)
       output = []
-      i=0
-      while multi_config[i] != nil
-        output << format_config(multi_config[i])
-        i += 1
+      multi_config.keys do |conf|
+        output << format_config(multi_config[conf])
       end
       output.join "\n"
     end

--- a/libraries/ini_helper.rb
+++ b/libraries/ini_helper.rb
@@ -1,5 +1,15 @@
 module GrafanaCookbook
   module IniHelper
+    def self.format_multi_config(multi_config)
+      output = []
+      i=0
+      while multi_config[i] != nil
+        output << format_config(multi_config[i])
+        i += 1
+      end
+      output.join "\n"
+    end
+
     def self.format_config(config)
       output = []
       config.each do |section, groups|

--- a/libraries/ini_helper.rb
+++ b/libraries/ini_helper.rb
@@ -2,7 +2,7 @@ module GrafanaCookbook
   module IniHelper
     def self.format_multi_config(multi_config)
       output = []
-      multi_config.keys do |conf|
+      multi_config.keys.each do |conf|
         output << format_config(multi_config[conf])
       end
       output.join "\n"

--- a/recipes/_ldap_config.rb
+++ b/recipes/_ldap_config.rb
@@ -1,9 +1,10 @@
 ldap = node['grafana']['ldap'].dup
 verbose_logging = node['grafana']['ldap_verbose_logging']
+multi_tree_auth = node['grafana']['ldap_multi_tree_auth']
 
 template node['grafana']['ini']['auth.ldap']['config_file']['value'] do
   source 'ldap.toml.erb'
-  variables verbose_logging: verbose_logging, config: ldap
+  variables verbose_logging: verbose_logging, config: ldap, multi_config: multi_tree_auth
   owner 'root'
   group 'root'
   mode '0644'

--- a/templates/default/ldap.toml.erb
+++ b/templates/default/ldap.toml.erb
@@ -8,4 +8,8 @@
 # Set to true to log user information returned from LDAP
 verbose_logging = <%= @verbose_logging %>
 
+<% if @multi_config != true %>
 <%= GrafanaCookbook::IniHelper.format_config @config %>
+<% else %>
+<%= GrafanaCookbook::IniHelper.format_multi_config @config %>
+<% end %>

--- a/templates/default/ldap.toml.erb
+++ b/templates/default/ldap.toml.erb
@@ -11,5 +11,5 @@ verbose_logging = <%= @verbose_logging %>
 <% if @multi_config != true %>
 <%= GrafanaCookbook::IniHelper.format_config @config %>
 <% else %>
-<%= GrafanaCookbook::IniHelper.format_multi_config @config %>
+<%= GrafanaCookbook::IniHelper.format_multi_config @config['multiconfig'] %>
 <% end %>


### PR DESCRIPTION
 _Added an attribute node['grafana']['ldap_multi_tree_auth']; when
  it is set to true, it is possible to configure to configure
  several ldap servers by using default['grafana']['ldap'][0],
  default['grafana']['ldap'][1]['[servers]']['host'], etc. instead
  of default['grafana']['ldap']['[servers]'] with the same syntax.
 _Added a function format_multi_config in GrafanaCookbook::IniHelper
  to handle configurations 'multiple' like the one above.