### PR TITLE
Replace chef_nginx by nginx

### DIFF
--- a/Berksfile
+++ b/Berksfile
@@ -2,7 +2,6 @@ source 'https://supermarket.chef.io'
 
 metadata
 
-cookbook 'chef_nginx'
 cookbook 'git'
 cookbook 'java'
 cookbook 'build-essential'

--- a/metadata.rb
+++ b/metadata.rb
@@ -14,4 +14,4 @@ recipe 'grafana::default', 'Installs and configures Grafana with a web server pr
 
 depends 'apt'
 depends 'yum'
-depends 'chef_nginx'
+depends 'nginx'

--- a/recipes/_nginx.rb
+++ b/recipes/_nginx.rb
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-include_recipe 'chef_nginx'
+include_recipe 'nginx'
 
 template '/etc/nginx/sites-available/grafana' do
   source node['grafana']['nginx']['template']


### PR DESCRIPTION
Chef has took over nginx cookbook which is now the official cookbook.
Keeping chef_nginx add a constraint on the Ohai cookbook at version 3.

This commit replace all references to chef_nginx by nginx.
Also remove the reference in the Berksfile, because it's properly set
in the metadata.