### PR TITLE
Support for installing plugin from a provided URL

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -113,9 +113,12 @@ suites:
           server:
             http_port: 3015
         package:
-          version : 3.0.3-1463994644
+          version : 4.6.3
         plugins:
          - grafana-clock-panel
+         -
+            id: raintank-worldping-app
+            url: https://grafana.com/api/plugins/raintank-worldping-app/versions/1.2.3/download
   # - name: source
   #   run_list:
   #     - recipe[grafana::default]

--- a/libraries/6_plugin.rb
+++ b/libraries/6_plugin.rb
@@ -8,13 +8,7 @@ module GrafanaCookbook
         cmd.run_command
         !cmd.stdout.split("\n").select { |item| item.include?('id:') && item.match(name) }.empty?
       else
-        response = Net::HTTP.get_response(URI(plugin_url))
-        case response
-          when Net::HTTPSuccess, Net::HTTPRedirection then
-            true
-          else
-            false
-          end
+        true
       end
     end
 

--- a/libraries/6_plugin.rb
+++ b/libraries/6_plugin.rb
@@ -2,10 +2,20 @@ module GrafanaCookbook
   module Plugin
     module_function
 
-    def available?(name, grafana_cli_bin)
-      cmd = Mixlib::ShellOut.new("#{grafana_cli_bin} plugins list-remote")
-      cmd.run_command
-      !cmd.stdout.split("\n").select { |item| item.include?('id:') && item.match(name) }.empty?
+    def available?(name, plugin_url, grafana_cli_bin)
+      if plugin_url.nil?
+        cmd = Mixlib::ShellOut.new("#{grafana_cli_bin} plugins list-remote")
+        cmd.run_command
+        !cmd.stdout.split("\n").select { |item| item.include?('id:') && item.match(name) }.empty?
+      else
+        response = Net::HTTP.get_response(URI(plugin_url))
+        case response
+          when Net::HTTPSuccess, Net::HTTPRedirection then
+            true
+          else
+            false
+          end
+      end
     end
 
     def installed?(name, grafana_cli_bin)
@@ -14,8 +24,8 @@ module GrafanaCookbook
       !cmd.stdout.split("\n").select { |item| item.include?('@') && item.match(name) }.empty?
     end
 
-    def build_cli_cmd(name, action, grafana_cli_bin)
-      "#{grafana_cli_bin} plugins #{action} #{name}"
+    def build_cli_cmd(name, plugin_url, action, grafana_cli_bin)
+      "#{grafana_cli_bin} #{plugin_url.nil? ? "" : "--pluginUrl #{plugin_url}"} plugins #{action} #{name}"
     end
   end
 end

--- a/providers/plugin.rb
+++ b/providers/plugin.rb
@@ -6,10 +6,11 @@ end
 
 action :install do
   plugin_name = new_resource.name
+  plugin_url = new_resource.plugin_url
   binary = new_resource.grafana_cli_bin
-  raise "#{plugin_name} is not available" unless ::GrafanaCookbook::Plugin.available?(plugin_name, binary)
+  raise "#{plugin_name} is not available" unless ::GrafanaCookbook::Plugin.available?(plugin_name, plugin_url, binary)
   execute "Installing plugin #{plugin_name}" do
-    command ::GrafanaCookbook::Plugin.build_cli_cmd(plugin_name, 'install', binary)
+    command ::GrafanaCookbook::Plugin.build_cli_cmd(plugin_name, plugin_url, 'install', binary)
     not_if { current_resource.installed }
   end
 end

--- a/recipes/plugins.rb
+++ b/recipes/plugins.rb
@@ -18,8 +18,16 @@
 #
 
 node['grafana']['plugins'].each do |p|
-  grafana_plugin p do
+  plugin = case
+    when p.kind_of?(Hash)
+      raise "Invalid plugin definition #{p}" if !p.has_key?('id') or !p.has_key?('url')
+      { 'id' => p['id'], 'url' => p['url'] }
+    else
+      { 'id' => p }
+  end
+  grafana_plugin plugin['id'] do
     action node['grafana']['plugins_action']
+    plugin_url plugin['url'] if plugin.has_key?('url')
     grafana_cli_bin node['grafana']['cli_bin']
   end
 end

--- a/resources/plugin.rb
+++ b/resources/plugin.rb
@@ -5,6 +5,7 @@ state_attrs :name
 
 # Resource properties
 attribute :name, name_attribute: true, kind_of: String, required: true
+attribute :plugin_url, kind_of: String, required: false, default: nil
 attribute :grafana_cli_bin, kind_of: String, required: false, default: '/usr/sbin/grafana-cli'
 
 attr_accessor :installed

--- a/test/integration/plugins/serverspec/spec/localhost/default_spec.rb
+++ b/test/integration/plugins/serverspec/spec/localhost/default_spec.rb
@@ -1,9 +1,10 @@
 require ::File.expand_path('../../spec_helper', __FILE__)
 
 describe command('grafana-server -v') do
-  its(:stdout) { should match /Version 3.0.3/ }
+  its(:stdout) { should match /Version 4.6.3/ }
 end
 
 describe command('grafana-cli plugins ls') do
   its(:stdout) { should match /grafana-clock-panel/ }
+  its(:stdout) { should match /raintank-worldping-app/ }
 end


### PR DESCRIPTION
Use `--pluginUrl` option to install the plugin instead of using the default registry when the `url` configuration is provided.
  